### PR TITLE
fix publish npm to use trusted publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -14,10 +14,15 @@ on:
         required: true
         default: latest
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,6 +43,3 @@ jobs:
       - name: Publish to npm
         if: ${{ inputs.publish }}
         run: npm publish --tag "${{ inputs.tag }}"
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-


### PR DESCRIPTION
Made changes to allow user to publish to npm manually from UI without managing NPM tokens etc.